### PR TITLE
Update utils.js

### DIFF
--- a/packages/serverless-components/domain/utils.js
+++ b/packages/serverless-components/domain/utils.js
@@ -81,7 +81,11 @@ const getOutdatedDomains = (inputs, state) => {
  * - These don't need to be created and SHOULD NOT be modified.
  */
 const getDomainHostedZoneId = async (route53, domain, privateZone) => {
-  const hostedZonesRes = await route53.listHostedZonesByName().promise();
+  const params = {
+    DNSName: domain
+  };
+  
+  const hostedZonesRes = await route53.listHostedZonesByName(params).promise();
 
   const hostedZone = hostedZonesRes.HostedZones.find(
     // Name has a period at the end, so we're using includes rather than equals
@@ -121,7 +125,7 @@ const getCertificateArnByDomain = async (acm, domain) => {
   for (const certificate of listRes.CertificateSummaryList) {
     if (certificate.DomainName === domain && certificate.CertificateArn) {
       if (domain.startsWith("www.")) {
-        const nakedDomain = domain.replace("wwww.", "");
+        const nakedDomain = domain.replace("www.", "");
         // check whether certificate support naked domain
         const certDetail = await describeCertificateByArn(
           acm,


### PR DESCRIPTION
Pass in the domain name as a DNSName parameter into AWS's listHostedZonesByName method.  This is particularly helpful for AWS accounts that have a large number of domains, since listHostedZonesByName only returns 100 records at a time.  Instead of paging through all records, we can filter the initial search.

Fix typo "wwww" to "www".